### PR TITLE
Patch: Travis-CI 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+# npmignore
+oz.test.config.js
+scripts/
+test/
+truffle-config.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,15 @@
 # travis-ci
 os: linux
 dist: xenial
-language: node_js
-node_js:
-  - '10'
-  - '12'
-  - '14'
+lang: generic
 
+before-install: npm install ganache-core && cd node_modules/ganache-core/node_modules/web3-provider-engine && npm install && npm i --global truffle@5.1.20
 git:
   quiet: true
 
 cache: npm
 
-before-install: npm i --global truffle@5.1.20
 install:
   - npm install
   
 script: true
-
-branches:
-  only:
-  - master


### PR DESCRIPTION
- fixes build issue with ci provider travis
- adds npmignore file for npm package registry publishing


see `.travis.yml` for details on fix, just involves installing ganache-core first before install 